### PR TITLE
Fix dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
     "require": {
         "php": ">=5.3.3",
         "mustache/mustache": "2.*",
-        "zendframework/zendframework-servicemanager": "2.*",
-        "zendframework/zendframework-view": "2.*",
-        "zendframework/zendframework-eventmanager": "2.*",
-        "zendframework/zendframework-modulemanager": "2.*"
+        "zendframework/zend-servicemanager": "2.*",
+        "zendframework/zend-view": "2.*",
+        "zendframework/zend-eventmanager": "2.*",
+        "zendframework/zend-modulemanager": "2.*"
     },
     "authors": [
         {


### PR DESCRIPTION
Currently anywhere `widmogrod/zf2-mustache-module` is required will automatically require the full ZF2 framework. I've reduced the dependency list to the actual dependencies. This will allow for a fewer installed ZF2 modules for people who want to use this module with specific components rather than the full framework.
