### PR TITLE
Fixed BLOCKS pragma issue, and enhanced configuration setup for loader and partials_loader

### DIFF
--- a/src/Mustache/Service/RendererFactory.php
+++ b/src/Mustache/Service/RendererFactory.php
@@ -38,16 +38,27 @@ class RendererFactory implements FactoryInterface
      */
     private function setConfigs(array $config) 
     {
-        if(isset($config["partials_loader"])) {
+        if(isset($config["partials_loader"]) && !is_object($config["partials_loader"])) {
             $path = $config["partials_loader"];
+            $options = array();
             if(is_array($config["partials_loader"])) {
                 $path = $config["partials_loader"][0];
+                unset($config["partials_loader"][0]);
+                if(is_array($config["partials_loader"]) && count($config["partials_loader"]) > 0){
+                    $options = $config["partials_loader"];
+                }
             }
-            $config["partials_loader"] = new \Mustache_Loader_FilesystemLoader($path);
+            $config["partials_loader"] = new \Mustache_Loader_FilesystemLoader($path, $options);
         }
         
-        if(isset($config["loader"])) {
-            $config["loader"] = new \Mustache_Loader_FilesystemLoader($config["loader"][0]);
+        if(isset($config["loader"]) && !is_object($config["loader"])) {
+            $options = array();
+            $path = $config["loader"][0];
+            unset($config["loader"][0]);
+            if(is_array($config["loader"]) && count($config["loader"]) > 0){
+                $options = $config["loader"];
+            }
+            $config["loader"] = new \Mustache_Loader_FilesystemLoader($path, $options);
         }
         return $config;
     }

--- a/src/Mustache/View/Renderer.php
+++ b/src/Mustache/View/Renderer.php
@@ -6,6 +6,7 @@ use Zend\View\Resolver\ResolverInterface;
 use Zend\View\Model\ModelInterface;
 use Zend\View\Model\ViewModel;
 use Mustache\Exception as Exception;
+use Zend\View\Variables;
 
 class Renderer implements RendererInterface
 {
@@ -91,10 +92,15 @@ class Renderer implements RendererInterface
         }
 
         $mustache = $this->getEngine();
-        return $mustache->render(
-            file_get_contents($file),
-            $values
-        );
+        if($values instanceof Variables && $values->offsetExists("content")){
+            $return = $values->offsetGet("content");
+        }else{
+            $return = $mustache->render(
+                file_get_contents($file),
+                $values
+            );
+        }
+        return $return;
     }
 
     /**


### PR DESCRIPTION
## Zend Framework 2 always viewed parent layout without the child view when using Blocks Pragma
- parent layout used to have expected display under attribute 'content' inside values object
- expected display is the parent layout with extended tags replaced with content in child view
- when content attribute is there, i display it's value directly
- **Ref.:** https://github.com/bobthecow/mustache.php/wiki/BLOCKS-pragma
## Add support for Mustache_Loader_FilesystemLoader options configuration
- Extension of loaded files is an option that can now be configured globally
- Mustache_Loader_FilesystemLoader object can now be supplied as a value for loader or partials_loader keys
- **Example:**

```
      'partials_loader' => array(
            dirname(__FILE__).'/../../layout',
            "extension" => ".phtml"
        )
```
